### PR TITLE
ci(release): fix latest and prerelease tags

### DIFF
--- a/.github/workflows/build-repo.yml
+++ b/.github/workflows/build-repo.yml
@@ -172,8 +172,8 @@ jobs:
           artifacts: repo/*
           bodyFile: README.md
           commit: master
-          makeLatest: ${{ matrix.repo == 'lizardbyte' && 'true' || 'false' }}
+          makeLatest: ${{ matrix.release_name == 'stable' || false }}
           name: ${{ matrix.release_name }}
-          prerelease: false
+          prerelease: ${{ matrix.release_name == 'beta' || false }}
           tag: ${{ matrix.release_name }}
           token: ${{ secrets.GH_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # LizardByte's Pacman Repository
 
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/LizardByte/pacman-repo/build-repo.yml?branch=master&event=schedule&style=for-the-badge&logo=github)](https://github.com/LizardByte/pacman-repo/actions/workflows/build-repo.yml?query=event%3Aschedule+branch%3Amaster)
+[![GitHub Downloads (all assets, specific tag)](https://img.shields.io/github/downloads/LizardByte/pacman-repo/beta/total?style=for-the-badge&logo=archlinux&label=daily%20downloads%40beta)](https://github.com/LizardByte/pacman-repo/releases/tag/beta)
+[![GitHub Downloads (all assets, specific tag)](https://img.shields.io/github/downloads/LizardByte/pacman-repo/latest/total?style=for-the-badge&logo=archlinux&label=daily%20downloads%40latest)](https://github.com/LizardByte/pacman-repo/releases/latest)
+
 Repository of Arch Linux packages for LizardByte packages.
 
 > [!CAUTION]


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fix the `latest` and `prerelease` tags for the generated releases.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
