### PR TITLE
ci(repo-builder): warn if srcinfo is mismatched

### DIFF
--- a/.github/workflows/build-repo.yml
+++ b/.github/workflows/build-repo.yml
@@ -167,13 +167,19 @@ jobs:
             --with-dereference-database-symlinks true \
             > build-pacman-repo.yaml
 
+          # validate .SRCINFO files
+          build-pacman-repo sync-srcinfo || \
+            echo "::warning:: .SRCINFO files mismatch" >> $GITHUB_STEP_SUMMARY && \
+            build-pacman-repo sync-srcinfo -u
+
+          # build the packages and create the repo
           build-pacman-repo build
 
           # ensure files are present in the repo
           repo_files=$(ls repo)
           if [[ -z "${repo_files}" ]]; then
-              echo "::error:: No files found in repo"
-              exit 1
+            echo "::error:: No files found in repo"
+            exit 1
           fi
 
       - name: Create/Update GitHub Release


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Warn CI if `.SRCINFO` file is outdated


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
